### PR TITLE
Fix: Correct 'Skills' nav link scrolling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,7 @@ body {
 html {
   scroll-behavior: smooth;
   outline: none;
+  scroll-padding-top: 80px;
 }
 
 ::selection {

--- a/src/components/skills/skills.tsx
+++ b/src/components/skills/skills.tsx
@@ -5,9 +5,9 @@ import "./skills.css";
 export default function Skills() {
     return (
         <>
-            <div id="skills"       style={{ marginBottom: "60px" }}
+            <div style={{ marginBottom: "60px" }}
             />
-            <div className="skillsC">
+            <div id="skills" className="skillsC">
                 <div className="title">     SKILLS 😎</div>
                 <div className="titleGap" />
                 <div className="titleGap" />


### PR DESCRIPTION
[Minifolio - anukriti2306's fork](https://github.com/anukriti2306/Minifolio)

# Short Description
This PR fixes the "Skills" link in the navigation bar, which was not scrolling to the correct position.

# Screenshot of the fix
<img width="1905" height="1013" alt="image" src="https://github.com/user-attachments/assets/6ba670ca-c395-4a3b-8217-905c17816137" />


# Points Added Or Removed
* **Removed:** The `id="skills"` from an empty `div` at the top of the Skills component.
* **Added:** The `id="skills"` to the main container `div` inside the Skills component for a correct anchor point.
* **Added:** `scroll-padding-top: 80px;` to `html` in `app/globals.css` to ensure the sticky header does not cover the section title after scrolling.

# Links To Issues
Closes #222 

# Files Changed
* `src/components/skills/skills.tsx` 
* `src/app/globals.css`